### PR TITLE
Handle docusign envelope creation error

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,14 @@ EMAIL_PASSWORD=your-app-password
 # Server Configuration
 PORT=3001
 NODE_ENV=development
+
+# DocuSign Configuration (JWT + Embedded Signing)
+DOCUSIGN_INTEGRATION_KEY=your_integration_key_guid
+DOCUSIGN_USER_ID=your_impersonated_user_guid
+# For multi-line private keys, keep quotes and \n escapes
+DOCUSIGN_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n....\n-----END RSA PRIVATE KEY-----\n"
+# This must match the redirect URI you registered in the DocuSign app
+DOCUSIGN_REDIRECT_URL=http://localhost:3001/api/docusign/callback
 ```
 
 ### 3. Firebase Setup
@@ -163,6 +171,15 @@ node test-subadmin.js
 - Check if user already exists in Firebase Auth
 - Verify all required fields are provided
 - Check Firestore permissions
+
+### DocuSign Issues
+- Make sure the DocuSign env vars are present: `DOCUSIGN_INTEGRATION_KEY`, `DOCUSIGN_USER_ID`, `DOCUSIGN_PRIVATE_KEY`, `DOCUSIGN_REDIRECT_URL`.
+- Grant consent once for JWT impersonation: open the URL from `GET /api/docusign/consent-url` in a browser, approve, then retry.
+- Verify outbound connectivity and DNS to DocuSign hosts. Call the health endpoint:
+  - `GET /api/docusign/health` should show `env` flags true and DNS lookups for `account-d.docusign.com` and `demo.docusign.net`.
+  - If you see `ENOTFOUND`, fix DNS or allowlist outbound HTTPS to DocuSign.
+- If you get `Signer is not configured for embedded signing`, ensure each recipient has a `clientUserId` when creating the envelope.
+- If you get `consent_required`, visit `/api/docusign/consent-url` and complete consent.
 
 ## Support
 

--- a/backend/routers/docusignRoutes.js
+++ b/backend/routers/docusignRoutes.js
@@ -16,5 +16,7 @@ router.get('/download-signed/:envelopeId', docusignController.downloadSignedDocu
 router.post('/send-to-seller', docusignController.sendToSeller);
 router.get('/seller-envelope-status/:envelopeId', docusignController.getSellerEnvelopeStatus);
 router.get('/download-seller-signed/:envelopeId', docusignController.downloadSellerSignedDocument);
+// Health check
+router.get('/health', docusignController.health);
 
 module.exports = router;


### PR DESCRIPTION
Adds a DocuSign health endpoint and improves error handling for network and configuration issues.

The previous DocuSign integration could fail with generic 500 errors (e.g., `getaddrinfo ENOTFOUND`) when network or environment variable issues prevented connection to DocuSign. This PR introduces a dedicated health endpoint and more specific error messages to help users quickly identify and resolve these underlying configuration and connectivity problems.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bb4463b-1692-45d1-99d9-8eb6167c179b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1bb4463b-1692-45d1-99d9-8eb6167c179b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

